### PR TITLE
Add memcachier support for Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source :rubygems
 
 gem 'rest-client'
 gem 'yajl-ruby'
+gem 'memcachier'
 gem 'dalli'
 gem 'sinatra'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
       excon (~> 0.13.3)
     launchy (2.1.0)
       addressable (~> 2.2.6)
+    memcachier (0.0.2)
     metaclass (0.0.1)
     mime-types (1.17.2)
     mocha (0.11.4)
@@ -51,6 +52,7 @@ DEPENDENCIES
   dalli
   fakeweb
   heroku
+  memcachier
   mocha
   rake
   rest-client

--- a/lib/pager_duty/incident.rb
+++ b/lib/pager_duty/incident.rb
@@ -1,5 +1,6 @@
 require 'rest_client'
 require 'yajl'
+require 'memcachier'
 require 'dalli'
 
 module PagerDuty


### PR DESCRIPTION
Couchbase is sunsetting the Memcache add-on for Heroku. Adding the `memcachier` gem will allow us to transparently use the Memcachier add-on (already added to prod) without any further modification or ENV var wrangling.

/cc @jnewland 
